### PR TITLE
Sample(k) and FastUtil

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,12 @@
       <artifactId>scalatest_2.11</artifactId>
       <version>3.0.0</version>
     </dependency>
-  </dependencies>
+    <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil</artifactId>
+      <version>7.0.9</version>
+    </dependency>
+    </dependencies>
 
   <build>
     <plugins>

--- a/src/main/java/org/hiero/sketch/table/FullMembership.java
+++ b/src/main/java/org/hiero/sketch/table/FullMembership.java
@@ -3,6 +3,10 @@ package org.hiero.sketch.table;
 import org.hiero.sketch.table.api.IMembershipSet;
 import org.hiero.sketch.table.api.IRowIterator;
 
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
 /**
  * A IMembershipSet which contains all rows.
  */
@@ -30,6 +34,40 @@ public class FullMembership implements IMembershipSet {
     @Override
     public IRowIterator getIterator() {
         return new FullMemebershipIterator(this.rowCount);
+    }
+
+    /**
+     * Samples k items. Does not seed the random generator so generator is seeded using its default
+     * method. Sampled items are first placed in a Set. The procedure samples k times with
+     * replacement so it may be that the returned set has less than k distinct items
+     * @param k
+     * @return ImembershipSet instantiated as a Partial Sparse
+     */
+    @Override
+    public IMembershipSet sample(int k) {
+        Random randomGenerator = new Random();
+        return sampleUtil(randomGenerator, k);
+    }
+
+    /**
+     * Same as sample(k) but with the seed of the generator given as a parameter. The procedure
+     * samples k times with replacement so it return a set with less than k distinct items
+     * @param k
+     * @param seed
+     * @return ImembershipSet instantiated as a partial sparse
+     */
+    @Override
+    public IMembershipSet sample (int k, long seed) {
+        Random randomGenerator = new Random(seed);
+        return sampleUtil(randomGenerator, k);
+    }
+
+    //todo: use the best set implementation.
+    private IMembershipSet sampleUtil(Random randomGenerator, int k) {
+        Set S = new HashSet<Integer>();
+        for (int i=0; i < k; i++)
+            S.add(randomGenerator.nextInt(this.rowCount));
+        return new PartialMembershipSparse(S);
     }
 
     private static class FullMemebershipIterator implements IRowIterator {

--- a/src/main/java/org/hiero/sketch/table/FullMembership.java
+++ b/src/main/java/org/hiero/sketch/table/FullMembership.java
@@ -1,5 +1,6 @@
 package org.hiero.sketch.table;
 
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import org.hiero.sketch.table.api.IMembershipSet;
 import org.hiero.sketch.table.api.IRowIterator;
 
@@ -32,14 +33,16 @@ public class FullMembership implements IMembershipSet {
     }
 
     @Override
+    public int getSize(boolean exact) { return this.rowCount; }
+
+    @Override
     public IRowIterator getIterator() {
         return new FullMemebershipIterator(this.rowCount);
     }
 
     /**
-     * Samples k items. Does not seed the random generator so generator is seeded using its default
-     * method. Sampled items are first placed in a Set. The procedure samples k times with
-     * replacement so it may be that the returned set has less than k distinct items
+     * Samples k items. Generator is seeded using its default method. Sampled items are first placed in a Set.
+     * The procedure samples k times with replacement so it may return a set with less than k distinct items.
      * @param k
      * @return ImembershipSet instantiated as a Partial Sparse
      */
@@ -64,7 +67,7 @@ public class FullMembership implements IMembershipSet {
 
     //todo: use the best set implementation.
     private IMembershipSet sampleUtil(Random randomGenerator, int k) {
-        Set S = new HashSet<Integer>();
+        IntOpenHashSet S = new IntOpenHashSet();
         for (int i=0; i < k; i++)
             S.add(randomGenerator.nextInt(this.rowCount));
         return new PartialMembershipSparse(S);

--- a/src/main/java/org/hiero/sketch/table/PartialMembershipSparse.java
+++ b/src/main/java/org/hiero/sketch/table/PartialMembershipSparse.java
@@ -1,10 +1,15 @@
 package org.hiero.sketch.table;
 
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntOpenCustomHashSet;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import org.hiero.sketch.table.api.IMembershipSet;
 import org.hiero.sketch.table.api.IRowIterator;
 import org.scalactic.exceptions.NullArgumentException;
 import java.util.*;
 import java.util.function.Predicate;
+import it.unimi.dsi.*;
 
 /**
  * This implementation uses a Set data structure to store the membership. It uses the Set's
@@ -17,40 +22,63 @@ import java.util.function.Predicate;
 public class PartialMembershipSparse implements IMembershipSet {
 
     private int rowCount;
-    private Set<Integer> membershipMap;
-
-    /* Standard way to construct this map is by supplying a memshipSet (perhaps the full one),
-    and the filter function passed as a lambda expression*/
+    private Set membershipMap;
+    /**
+     * Standard way to construct this map is by supplying a membershipSet (perhaps the full one),
+     * and the filter function passed as a lambda expression.
+     * @param baseMap
+     * @param filter
+     * @throws NullArgumentException
+     */
     public PartialMembershipSparse(IMembershipSet baseMap, Predicate<Integer> filter)
             throws NullArgumentException {
         if (baseMap == null)
             throw new NullArgumentException("PartialMembershipDense cannot be instantiated " +
                     "without a base MembershipSet");
         if (filter == null)
-            filter = Integer -> { return true; };
+            throw new NullArgumentException("Predicate for PartialMembershipDense cannot be null");
         IRowIterator baseIterator = baseMap.getIterator();
-        membershipMap = new HashSet<Integer>();
+        this.membershipMap = new IntOpenHashSet();
         int tmp = baseIterator.getNextRow();
         while (tmp >= 0) {
             if (filter.test(tmp))
-                membershipMap.add(tmp);
+                this.membershipMap.add(tmp);
             tmp = baseIterator.getNextRow();
         }
-        this.rowCount = membershipMap.size();
+        this.rowCount = this.membershipMap.size();
     }
 
+    /**
+     * Instantiates the class without a new predicate. Effectively converts the implemenation of
+     * the basemap into that of a sparse map.
+     * @param baseMap of type ImembershipSet
+     * @throws NullArgumentException
+     */
     public PartialMembershipSparse(IMembershipSet baseMap) throws NullArgumentException {
         if (baseMap == null)
             throw new NullArgumentException("PartialMembershipDense cannot be instantiated " +
                     "without a base MembershipSet");
         IRowIterator baseIterator = baseMap.getIterator();
-        membershipMap = new HashSet<Integer>();
+        this.membershipMap = new IntOpenHashSet();
         int tmp = baseIterator.getNextRow();
         while (tmp >= 0) {
-            membershipMap.add(tmp);
+            this.membershipMap.add(tmp);
             tmp = baseIterator.getNextRow();
         }
-        this.rowCount = membershipMap.size();
+        this.rowCount = this.membershipMap.size();
+    }
+
+    /**
+     * Essentially wraps a Set interface by  ImembershipSet
+     * @param baseSet of type Set
+     * @throws NullArgumentException
+     */
+    public PartialMembershipSparse(Set baseSet) throws NullArgumentException {
+        if (baseSet == null)
+            throw new NullArgumentException("PartialMembershipDense cannot be instantiated " +
+                    "without a base Set");
+        this.membershipMap = baseSet;
+        this.rowCount = this.membershipMap.size();
     }
 
     @Override
@@ -63,19 +91,53 @@ public class PartialMembershipSparse implements IMembershipSet {
         return this.rowCount;
     }
 
+    /** TODO This is a PLACEHOLDER
+     * Returns the first k items from the map. Actually may make sense dependeing on the
+     * implementation of the OpenHashSet
+     */
+    @Override
+    public IMembershipSet sample(int k) {
+        Set<Integer> sampleSet = new IntOpenHashSet();
+        IRowIterator it = this.getIterator();
+        for (int i = 0; i < k; i++ ) {
+            int tmp = it.getNextRow();
+            if (tmp < 0)
+                return new PartialMembershipSparse(sampleSet);
+            sampleSet.add(tmp);
+        }
+        return new PartialMembershipSparse(sampleSet);
+    }
+
+    /** TODO This is a PLACEHOLDER
+     * Returns the first k items from the map. Actually may make sense dependeing on the
+     * implementation of the OpenHashSet, though not clear how to pass the seed.
+     */
+    @Override
+    public IMembershipSet sample(int k, long seed) {
+        Set<Integer> sampleSet = new IntOpenHashSet();
+        IRowIterator it = this.getIterator();
+        for (int i = 0; i < k; i++ ) {
+            int tmp = it.getNextRow();
+            if (tmp < 0)
+                return new PartialMembershipSparse(sampleSet);
+            sampleSet.add(tmp);
+        }
+        return new PartialMembershipSparse(sampleSet);
+    }
+
     @Override
     public IRowIterator getIterator() {
-        return new SparseIterator(membershipMap);
+        return new SparseIterator(this.membershipMap);
     }
 
     // Implementing the Iterator
     private static class SparseIterator implements IRowIterator {
-        private Set<Integer> mempershipMap;
+        private Set<Integer> membershipMap;
         private Iterator<Integer> myIterator;
 
         public SparseIterator(Set<Integer> membershipMap) {
-            this.mempershipMap = membershipMap;
-            this.myIterator = membershipMap.iterator();
+            this.membershipMap = membershipMap;
+            this.myIterator = this.membershipMap.iterator();
         }
 
         public int getNextRow() {

--- a/src/main/java/org/hiero/sketch/table/api/IMembershipSet.java
+++ b/src/main/java/org/hiero/sketch/table/api/IMembershipSet.java
@@ -17,15 +17,22 @@ public interface IMembershipSet {
     int getSize();
 
     /**
+     * @return If exact==true returns the total umber of elements in this membership map. If exact==false may
+     * return an approximation of that number. An approximation may be much quicker to compute so if an approximation
+     * is sufficient it is recommended to set exact==false.
+     */
+    int getSize(boolean exact);
+    /**
      * @return an ImembershipSet containing k samples from the membership map. The samples are made
-     * with replacement so may contain less than k distinct values.
+     * with replacement so may contain less than k distinct values. There is no guarantee that two subsequent samples
+     * return the same sample set.
      */
     IMembershipSet sample(int k);
 
     /**
      * @return an ImembershipSet containing k samples from the membership map. The samples are made
      * with replacement so may contain less than k distinct values. The pseudo-random generated
-     * is seeded with parameter seed.
+     * is seeded with parameter seed, so subsequent calls with the same seed are guaranteed to return the same sample.
      */
     IMembershipSet sample(int k, long seed);
     /**

--- a/src/main/java/org/hiero/sketch/table/api/IMembershipSet.java
+++ b/src/main/java/org/hiero/sketch/table/api/IMembershipSet.java
@@ -15,6 +15,19 @@ public interface IMembershipSet {
      * @return Total number of elements in this membership map.
      */
     int getSize();
+
+    /**
+     * @return an ImembershipSet containing k samples from the membership map. The samples are made
+     * with replacement so may contain less than k distinct values.
+     */
+    IMembershipSet sample(int k);
+
+    /**
+     * @return an ImembershipSet containing k samples from the membership map. The samples are made
+     * with replacement so may contain less than k distinct values. The pseudo-random generated
+     * is seeded with parameter seed.
+     */
+    IMembershipSet sample(int k, long seed);
     /**
      * @return An iterator over all the rows in the membership map.
      * The iterator is initialized to point at the "first" row.

--- a/src/test/java/org/hiero/sketch/MembershipTest.java
+++ b/src/test/java/org/hiero/sketch/MembershipTest.java
@@ -3,6 +3,7 @@ package org.hiero.sketch;
 import org.hiero.sketch.table.FullMembership;
 import org.hiero.sketch.table.PartialMembershipDense;
 import org.hiero.sketch.table.PartialMembershipSparse;
+import org.hiero.sketch.table.api.IMembershipSet;
 import org.hiero.sketch.table.api.IRowIterator;
 import org.junit.Test;
 
@@ -25,6 +26,19 @@ public class MembershipTest {
         assert(FM.isMember(7));
         assert(!FM.isMember(-2));
         assert(!FM.isMember(-10));
+        IMembershipSet mysample = FM.sample(5);
+        System.out.println("printing sample of 5 elements: ");
+        PrintMemebership(mysample);
+
+    }
+
+    private void PrintMemebership(IMembershipSet myset) {
+        IRowIterator it = myset.getIterator();
+        int tmp = it.getNextRow();
+        while (tmp >=0 ) {
+            System.out.print(tmp + ",");
+            tmp = it.getNextRow();
+        }
     }
 
     @Test
@@ -35,13 +49,11 @@ public class MembershipTest {
         assert(PMD.isMember(6));
         assert(!PMD.isMember(7));
         System.out.println("Size of Dense Membership is: " + PMD.getSize());
-        IRowIterator IT = PMD.getIterator();
-        int tmp = IT.getNextRow();
-        while (tmp >=0 ) {
-            System.out.print(tmp+",");
-            tmp = IT.getNextRow();
-        }
+        PrintMemebership(PMD);
         System.out.println();
+        IMembershipSet mysample = PMD.sample(5);
+        System.out.println("printing sample of 5 elements: ");
+        PrintMemebership(mysample);
     }
 
     @Test
@@ -52,12 +64,10 @@ public class MembershipTest {
         assert(PMS.isMember(6));
         assert(!PMS.isMember(7));
         System.out.println("Size of Sparse Membership is: " + PMS.getSize());
-        IRowIterator IT = PMS.getIterator();
-        int tmp = IT.getNextRow();
-        while (tmp >= 0) {
-            System.out.print(tmp+",");
-            tmp = IT.getNextRow();
-        }
+        PrintMemebership(PMS);
         System.out.println();
+        IMembershipSet mysample = PMS.sample(5);
+        System.out.println("printing sample of 5 elements: ");
+        PrintMemebership(mysample);
     }
 }


### PR DESCRIPTION
Implemented sample(k) and sample(k, seed). The implementation in PartialMembershipMapSparse is a placeholder that just returns the first k items the iterator provides. 
Also added the library FastUtil for the type specific sets we used. Even without tuning the tests run 5 times faster.
